### PR TITLE
Add Supabase temporary directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Supabase
+supabase/.temp/


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to exclude Supabase's temporary directory from version control.

## Changes
- Added `supabase/.temp/` to `.gitignore` to prevent temporary files generated by Supabase from being committed to the repository

## Details
This prevents temporary build artifacts and cache files created by Supabase CLI operations from cluttering the git repository and being accidentally committed.

https://claude.ai/code/session_01GuuvaZZp32BZZHXw7TgbPd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated repository configuration to exclude Supabase temporary files from version control, improving repository cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->