### PR TITLE
fix: use VITE_BACKEND_URL env var, standardize endpoints

### DIFF
--- a/src/hooks/usePassiveAd.ts
+++ b/src/hooks/usePassiveAd.ts
@@ -31,7 +31,7 @@ export const usePassiveAd = (
           return;
         }
 
-        const startResponse = await fetch(`https://secret-share-backend-production.up.railway.app/api/ads/start`, {
+        const startResponse = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/ads/start`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ user_id: userId, type: 'interstitial' })
@@ -42,7 +42,7 @@ export const usePassiveAd = (
         const session = await startResponse.json();
         await showMonetag(session.session_id);
 
-        const completeResponse = await fetch(`https://secret-share-backend-production.up.railway.app/api/ads/complete`, {
+        const completeResponse = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/ads/complete`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -71,7 +71,7 @@ export const usePassiveAd = (
 
     const checkEligibility = async (userId: number) => {
       const response = await fetch(
-        `https://secret-share-backend-production.up.railway.app/api/ads/eligibility?user_id=${userId}&type=interstitial&first_session=0`
+        `${import.meta.env.VITE_BACKEND_URL}/api/ads/eligibility?user_id=${userId}&type=interstitial&first_session=0`
       );
       if (!response.ok) throw new Error(`Eligibility check failed: ${response.status}`);
       return await response.json();

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -51,7 +51,7 @@ const Leaderboard = () => {
     
     try {
       const response = await fetch(
-        `https://secret-share-backend-production.up.railway.app/api/arena/leaderboard?period=${selectedPeriod}&limit=50`
+        `${import.meta.env.VITE_BACKEND_URL}/api/arena/leaderboard?period=${selectedPeriod}&limit=50`
       );
       
       if (!response.ok) {

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -196,7 +196,7 @@ const Store = () => {
       const packageType = `gems_${gemPackage.gems}`;
 
       // Create invoice via backend using the approved method
-      const response = await fetch('https://secret-share-backend-production.up.railway.app/api/create-invoice', {
+      const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/create-invoice`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -337,7 +337,7 @@ const Store = () => {
       const packageType = `sub_${planName.toLowerCase()}`;
 
       // Create invoice via backend using the new subscription endpoint
-      const response = await fetch('https://secret-share-backend-production.up.railway.app/create_invoice_link', {
+      const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/create-invoice`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -482,7 +482,7 @@ const Store = () => {
 
     try {
       // Use correct endpoint and package type for intro subscription
-      const response = await fetch('https://secret-share-backend-production.up.railway.app/create_invoice_link', {
+      const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/create-invoice`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/services/adService.ts
+++ b/src/services/adService.ts
@@ -28,7 +28,7 @@ export interface AdStatusResponse {
 export type AdType = 'interstitial' | 'quick' | 'bonus';
 
 class AdService {
-  private baseUrl = 'https://secret-share-backend-production.up.railway.app';
+  private baseUrl = import.meta.env.VITE_BACKEND_URL || 'https://secret-share-backend-production.up.railway.app';
   private isAdRunning = false;
 
   // Debounce mechanism to ensure only one ad runs at a time


### PR DESCRIPTION
## Summary
- Replace all 8 hardcoded backend URLs with `import.meta.env.VITE_BACKEND_URL` across 4 files
- Standardize `/create_invoice_link` → `/api/create-invoice` for subscription/intro invoices
- `VITE_BACKEND_URL` was already defined in `.env` but never used — now it is

**Files changed:** Store.tsx, adService.ts, usePassiveAd.ts, Leaderboard.tsx

## Test plan
- [ ] Verify gem purchases work (Store → buy gems)
- [ ] Verify subscription purchases work (Store → subscribe)
- [ ] Verify intro offer purchases work (Store → intro)
- [ ] Verify ad flows work (earn modal → watch ad)
- [ ] Verify leaderboard loads (arena → leaderboard)
- [ ] Verify `VITE_BACKEND_URL` env var is set on Vercel

https://claude.ai/code/session_01GuuvaZZp32BZZHXw7TgbPd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend URLs to use environment variables instead of hardcoded values across ad, leaderboard, store, and service endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->