### PR TITLE
feat: enable ads-offer-webhook edge function as backup handler

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -12,6 +12,5 @@ verify_jwt = false
 [functions.admin-blog-operations]
 verify_jwt = false
 
-# [functions.ads-offer-webhook]
-# verify_jwt = false
-# DISABLED: Using Railway webhook only to prevent double-crediting
+[functions.ads-offer-webhook]
+verify_jwt = false


### PR DESCRIPTION
- Uncomment ads-offer-webhook in supabase config.toml (deployed via CLI)
- Edge function serves as backup if Railway primary webhook is down

https://claude.ai/code/session_01GuuvaZZp32BZZHXw7TgbPd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled the ads-offer webhook service to process incoming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->