### PR TITLE
fix: Monetag SDK pop call — use single options object instead of two args

### DIFF
--- a/src/services/adService.ts
+++ b/src/services/adService.ts
@@ -164,17 +164,13 @@ class AdService {
             .then((result: any) => resolve(result))
             .catch((error: any) => reject(error));
         } else if (type === 'pop') {
-          // Set global options as fallback if SDK doesn't carry options properly
-          if (sessionId) {
-            (window as any).monetagOpts = { ymid: sessionId, requestVar: sessionId };
-          }
-          monetag('pop', options)
+          // Monetag SDK expects a single options object, NOT ('pop', options)
+          // See: https://docs.monetag.com/docs/sdk-reference/
+          options.type = 'pop';
+          console.log('[AdService] Calling show_9674140 with pop options:', options);
+          monetag(options)
             .then((result: any) => resolve(result))
-            .catch((error: any) => reject(error))
-            .finally(() => {
-              // Clear global to avoid leaking session
-              delete (window as any).monetagOpts;
-            });
+            .catch((error: any) => reject(error));
         } else {
           // Default rewarded interstitial
           monetag(sessionId ? options : undefined)


### PR DESCRIPTION
## Summary
- Monetag SDK `show_9674140()` accepts either a string shorthand OR a single options object — NOT two arguments
- Previous code: `monetag("pop", options)` — SDK ignores the second arg, popup fails every time
- Fixed: `monetag({ type: "pop", ymid: sessionId, requestVar: sessionId })` — single options object
- This was the root cause of bonus ads consistently showing "Ad unavailable" to users

Per [Monetag SDK Reference](https://docs.monetag.com/docs/sdk-reference/)

## Test plan
- [ ] Have a user trigger a bonus ad
- [ ] Verify popup actually opens (no more "Ad unavailable" error)
- [ ] Check ad_sessions table for bonus session progressing past "started"

https://claude.ai/code/session_015xGytchhzoVsjB9aYe33Xc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of pop-up advertisements with streamlined SDK invocation patterns
  * Reduced global state dependencies for cleaner code architecture and enhanced maintainability
  * Enhanced debugging capabilities through improved logging of advertisement operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->