### PR TITLE
docs: update CLAUDE-frontend.md — Monetag postbacks fully configured

### DIFF
--- a/CLAUDE-frontend.md
+++ b/CLAUDE-frontend.md
@@ -190,17 +190,18 @@ Isabella is #1 by user count (2,600 users). Luna is lowest (622).
 4. Frontend polls `/api/ads/status` for bonus/quick fallback
 5. Interstitial: NO frontend complete call — webhook only
 
-### Postback URL format (Monetag dashboard)
+### Postback URL format (Monetag dashboard) — ✅ Updated March 14, 2026
 ```
-https://pfuyxdqzbrjrtqlbkbku.supabase.co/functions/v1/ads-offer-webhook?session_id={ymid}&user_id={telegram_id}&reward={reward}&event_type={event_type}&zone_id={zone_id}&subzone_id={subzone_id}&price={estimated_price}
+https://secret-share-backend-production.up.railway.app/api/ads/offer-webhook?session_id={ymid}&user_id={telegram_id}&reward={reward_event_type}&event_type={event_type}&zone_id={zone_id}&subzone_id={sub_zone_id}&price={estimated_price}
 ```
+> Postbacks activated for zone 9674140 (confirmed by Monetag support).
 
 ---
 
 ## REMAINING KNOWN ISSUES
 
-1. ~~**Interstitial/bonus ads 0% completion**~~ ✅ FIXED (March 10, 2026)
-2. **Monetag postback URL**: Must be configured in Monetag dashboard to point to edge function URL with correct macros (see above)
+1. ~~**Interstitial/bonus ads 0% completion**~~ ✅ FULLY FIXED (March 14, 2026) — code fixed March 10-11; Monetag postback URL updated to Railway backend with correct macros; postbacks activated for zone 9674140.
+2. ~~**Monetag postback URL**~~ ✅ DONE — Configured in Monetag dashboard pointing to Railway backend with correct macros (`{reward_event_type}`, `{sub_zone_id}`)
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated Monetag postback URL to point to Railway backend with correct macros (`{reward_event_type}`, `{sub_zone_id}`)
- Marked postback activation as done (confirmed by Monetag support for zone 9674140)
- Marked all ad completion issues as fully resolved

## Test plan
- [ ] Verify bonus ad completions start appearing in `ad_sessions` table with status `completed`

https://claude.ai/code/session_015xGytchhzoVsjB9aYe33Xc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated postback webhook URL and parameters for ad offer integration.
  * Renamed query parameter `subzone_id` to `sub_zone_id` and adjusted `reward` parameter format.
  * Added confirmation note on postback activation for a specific zone.
  * Updated known issues status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->