### PR TITLE
feat: Secret Score info button + tooltip updates

### DIFF
--- a/CLAUDE-frontend.md
+++ b/CLAUDE-frontend.md
@@ -5,6 +5,16 @@
 
 ---
 
+## DEPLOYMENT WORKFLOW
+
+**IMPORTANT**: Always create a PR to merge changes into `main` when making any frontend changes. Vercel auto-deploys from `main` — the Telegram mini-app only shows production deployments (merged to `main`), not preview deployments from feature branches. Workflow:
+1. Develop on feature branch
+2. Commit and push to feature branch
+3. Create PR to merge into `main`
+4. Once merged, Vercel auto-deploys to production
+
+---
+
 ## REPO INFO
 
 - **Repo**: https://github.com/yss-420/secret-share-frontend

--- a/src/components/SecretScoreInfoButton.tsx
+++ b/src/components/SecretScoreInfoButton.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+
+export const SecretScoreInfoButton = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <button className="inline-flex items-center px-3 py-1.5 rounded-full bg-primary/10 border border-primary/20 gap-1.5 cursor-pointer">
+          <svg
+            width={14}
+            height={14}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+              fill="#EF4444"
+            />
+          </svg>
+          <span className="text-xs text-primary font-medium">Secret Score</span>
+        </button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle className="text-lg">🧪 Secret Score</DrawerTitle>
+          <DrawerDescription>How your chemistry score works</DrawerDescription>
+        </DrawerHeader>
+        <div className="px-4 pb-6 space-y-4 text-sm">
+          <p className="text-muted-foreground">
+            Your Secret Score reflects how deep your connection with each
+            companion is. The more you chat, the higher it grows!
+          </p>
+
+          <div className="space-y-2">
+            <p className="font-medium text-white">How to raise your score:</p>
+            <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
+              <li>Chat more with your companions</li>
+              <li>Send longer, more engaging messages</li>
+              <li>Flirty conversations boost it faster</li>
+              <li>Stay consistent — daily activity matters</li>
+            </ul>
+          </div>
+
+          <p className="text-red-400/80">
+            ⚠️ Your score decreases after 2 days of inactivity
+          </p>
+
+          <p className="text-purple-300">
+            🎁 A special bonus awaits at 100%...
+          </p>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,7 @@ import { FreeGemsButton } from '@/components/FreeGemsButton';
 import { EarnModal } from '@/components/EarnModal';
 import { adService } from '@/services/adService';
 import { useChemistryScores } from '@/hooks/useChemistryScores';
+import { SecretScoreInfoButton } from '@/components/SecretScoreInfoButton';
 
 const Index = () => {
   const [earnModalOpen, setEarnModalOpen] = useState(false);
@@ -97,7 +98,8 @@ const Index = () => {
       <div className="relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-accent/5" />
         <div className="relative px-4 pt-6 pb-4">
-          <div className="text-center mb-2">
+          <div className="flex items-center justify-center gap-2 mb-2">
+            <SecretScoreInfoButton />
             {user && (
               <div className="inline-flex items-center px-3 py-1.5 rounded-full bg-primary/10 border border-primary/20 mb-4">
                 <div className="w-1.5 h-1.5 bg-primary rounded-full mr-2" />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -98,10 +98,10 @@ const Index = () => {
       <div className="relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-accent/5" />
         <div className="relative px-4 pt-6 pb-4">
-          <div className="flex items-center justify-center gap-2 mb-2">
+          <div className="flex items-center justify-center gap-2 mb-4">
             <SecretScoreInfoButton />
             {user && (
-              <div className="inline-flex items-center px-3 py-1.5 rounded-full bg-primary/10 border border-primary/20 mb-4">
+              <div className="inline-flex items-center px-3 py-1.5 rounded-full bg-primary/10 border border-primary/20">
                 <div className="w-1.5 h-1.5 bg-primary rounded-full mr-2" />
                 <span className="text-xs text-primary font-medium">
                   Welcome, {user.nickname || user.user_name || 'Developer'}!


### PR DESCRIPTION
## Summary
- **Secret Score info button**: New red heart pill on home page (left of Welcome pill) that opens a bottom drawer explaining what Secret Score is, how to raise it, inactivity warning, and 100% bonus tease
- **Updated ChemistryHeart tooltip**: Added score explanation, explicit 2-day inactivity warning, vague bonus tease (no subscriber/reward details)
- **Interstitial ad fix**: Mark interstitial ads complete on SDK resolve (interstitials award 0 gems, no exploit risk)

## Test plan
- [ ] Open Telegram mini-app — red heart Secret Score pill visible left of Welcome pill
- [ ] Tap the pill — bottom drawer slides up with explanation
- [ ] Character cards still navigate correctly on tap
- [ ] Free Gems button still works

https://claude.ai/code/session_01HFgvWaGctUkFbJ3V3x3FUh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Secret Score information button with an expandable panel containing detailed information, instructions, and guidance about the Secret Score feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->