### PR TITLE
feat: redesign Secret Score button + animated heart

### DIFF
--- a/src/components/SecretScoreInfoButton.tsx
+++ b/src/components/SecretScoreInfoButton.tsx
@@ -8,58 +8,83 @@ import {
   DrawerDescription,
 } from "@/components/ui/drawer";
 
+const heartbeatStyle = `
+@keyframes heartbeat {
+  0%, 100% { transform: scale(0.8); opacity: 0.6; }
+  50% { transform: scale(1.15); opacity: 1; }
+}
+`;
+
 export const SecretScoreInfoButton = () => {
   const [open, setOpen] = useState(false);
 
   return (
-    <Drawer open={open} onOpenChange={setOpen}>
-      <DrawerTrigger asChild>
-        <button className="inline-flex items-center px-3 py-1.5 rounded-full bg-primary/10 border border-primary/20 gap-1.5 cursor-pointer">
-          <svg
-            width={14}
-            height={14}
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
-              fill="#EF4444"
-            />
-          </svg>
-          <span className="text-xs text-primary font-medium">Secret Score</span>
-        </button>
-      </DrawerTrigger>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle className="text-lg">🧪 Secret Score</DrawerTitle>
-          <DrawerDescription>How your chemistry score works</DrawerDescription>
-        </DrawerHeader>
-        <div className="px-4 pb-6 space-y-4 text-sm">
-          <p className="text-muted-foreground">
-            Your Secret Score reflects how deep your connection with each
-            companion is. The more you chat, the higher it grows!
-          </p>
+    <>
+      <style>{heartbeatStyle}</style>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerTrigger asChild>
+          <button className="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg bg-rose-600/90 backdrop-blur-sm border border-rose-500/50 shadow-lg shadow-rose-500/25 text-white text-xs font-medium transition-all duration-300 hover:bg-rose-700 cursor-pointer">
+            <svg
+              width={14}
+              height={14}
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+                fill="white"
+              />
+            </svg>
+            <span>Secret Score</span>
+          </button>
+        </DrawerTrigger>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle className="text-lg flex items-center gap-2">
+              <svg
+                width={22}
+                height={22}
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                style={{ animation: "heartbeat 2s ease-in-out infinite" }}
+              >
+                <path
+                  d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+                  fill="#EF4444"
+                />
+              </svg>
+              Secret Score
+            </DrawerTitle>
+            <DrawerDescription>How your chemistry score works</DrawerDescription>
+          </DrawerHeader>
+          <div className="px-4 pb-6 space-y-4 text-sm">
+            <p className="text-muted-foreground">
+              Your Secret Score reflects how deep your connection with each
+              companion is. The more you chat, the higher it grows!
+            </p>
 
-          <div className="space-y-2">
-            <p className="font-medium text-white">How to raise your score:</p>
-            <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
-              <li>Chat more with your companions</li>
-              <li>Send longer, more engaging messages</li>
-              <li>Flirty conversations boost it faster</li>
-              <li>Stay consistent — daily activity matters</li>
-            </ul>
+            <div className="space-y-2">
+              <p className="font-medium text-white">How to raise your score:</p>
+              <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
+                <li>Chat more with your companions</li>
+                <li>Send longer, more engaging messages</li>
+                <li>Flirty conversations boost it faster</li>
+                <li>Stay consistent — daily activity matters</li>
+              </ul>
+            </div>
+
+            <p className="text-red-400/80">
+              ⚠️ Your score decreases after 2 days of inactivity
+            </p>
+
+            <p className="text-purple-300">
+              🎁 A special bonus awaits at 100%...
+            </p>
           </div>
-
-          <p className="text-red-400/80">
-            ⚠️ Your score decreases after 2 days of inactivity
-          </p>
-
-          <p className="text-purple-300">
-            🎁 A special bonus awaits at 100%...
-          </p>
-        </div>
-      </DrawerContent>
-    </Drawer>
+        </DrawerContent>
+      </Drawer>
+    </>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -98,8 +98,10 @@ const Index = () => {
       <div className="relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-accent/5" />
         <div className="relative px-4 pt-6 pb-4">
-          <div className="flex items-center justify-center gap-2 mb-4">
-            <SecretScoreInfoButton />
+          <div className="relative flex items-center justify-center mb-4">
+            <div className="absolute left-0">
+              <SecretScoreInfoButton />
+            </div>
             {user && (
               <div className="inline-flex items-center px-3 py-1.5 rounded-full bg-primary/10 border border-primary/20">
                 <div className="w-1.5 h-1.5 bg-primary rounded-full mr-2" />


### PR DESCRIPTION
## Summary
- **Secret Score button redesigned** as a box/card (like Free Gems button) — rose-colored, rounded-lg, shadow, glass effect, clearly clickable
- **Button positioned on the left**, Welcome pill stays centered
- **Animated heart in drawer** — replaces 🧪 test tube emoji with a pulsing red heart SVG (fills up → shrinks → loop)

## Test plan
- [ ] Secret Score button appears on the left as a rose-colored box (not a pill)
- [ ] Welcome pill stays centered regardless of button width
- [ ] Tapping Secret Score opens the drawer
- [ ] Drawer title shows animated pulsing heart (no test tube emoji)
- [ ] Character cards, Free Gems, navigation all still work

https://claude.ai/code/session_01HFgvWaGctUkFbJ3V3x3FUh