### PR TITLE
Phase 0a (frontend): send Telegram initData on ad + invoice calls

### DIFF
--- a/src/hooks/usePassiveAd.ts
+++ b/src/hooks/usePassiveAd.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { telegramAuthHeaders } from '../lib/telegramAuth';
 
 const isDev = import.meta.env.DEV;
 const log = (...args: any[]) => { if (isDev) console.log('[usePassiveAd]', ...args); };
@@ -40,7 +41,7 @@ export const usePassiveAd = (
 
         const startResponse = await fetch(`${BACKEND_URL}/api/ads/start`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
           body: JSON.stringify({ user_id: userId, type: 'interstitial' })
         });
 
@@ -60,7 +61,7 @@ export const usePassiveAd = (
           try {
             await fetch(`${BACKEND_URL}/api/ads/complete`, {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
               body: JSON.stringify({
                 user_id: userId,
                 type: 'interstitial',
@@ -77,7 +78,7 @@ export const usePassiveAd = (
           try {
             await fetch(`${BACKEND_URL}/api/ads/complete`, {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
               body: JSON.stringify({
                 user_id: userId,
                 type: 'interstitial',
@@ -107,7 +108,8 @@ export const usePassiveAd = (
 
     const checkEligibility = async (userId: number) => {
       const response = await fetch(
-        `${BACKEND_URL}/api/ads/eligibility?user_id=${userId}&type=interstitial&first_session=0`
+        `${BACKEND_URL}/api/ads/eligibility?user_id=${userId}&type=interstitial&first_session=0`,
+        { headers: telegramAuthHeaders() }
       );
       if (!response.ok) throw new Error(`Eligibility check failed: ${response.status}`);
       return await response.json();

--- a/src/lib/telegramAuth.ts
+++ b/src/lib/telegramAuth.ts
@@ -1,0 +1,16 @@
+// Telegram Mini-App auth helper.
+// The backend authenticates money/ad requests by verifying the signed Telegram initData
+// (HMAC with the bot token) and derives the user id from it — it no longer trusts a
+// client-supplied user_id. Every call to /api/ads/* and /api/create-invoice must send this header.
+
+export function getTelegramInitData(): string {
+  return (window as any)?.Telegram?.WebApp?.initData || '';
+}
+
+// Merge the X-Telegram-Init-Data header into an existing headers object.
+export function telegramAuthHeaders(
+  extra: Record<string, string> = {}
+): Record<string, string> {
+  const initData = getTelegramInitData();
+  return initData ? { ...extra, 'X-Telegram-Init-Data': initData } : { ...extra };
+}

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,4 +1,5 @@
 
+import { telegramAuthHeaders } from "@/lib/telegramAuth";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -200,9 +201,7 @@ const Store = () => {
       // Create invoice via backend using the approved method
       const response = await fetch(`${BACKEND_URL}/api/create-invoice`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({
           user_id: telegramUser.id,
           package_type: packageType
@@ -341,9 +340,7 @@ const Store = () => {
       // Create invoice via backend using the new subscription endpoint
       const response = await fetch(`${BACKEND_URL}/api/create-invoice`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({
           user_id: telegramUser.id,
           package_type: packageType
@@ -486,9 +483,7 @@ const Store = () => {
       // Use correct endpoint and package type for intro subscription
       const response = await fetch(`${BACKEND_URL}/api/create-invoice`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({
           user_id: telegramUser.id,
           package_type: 'intro_3d',

--- a/src/services/adService.ts
+++ b/src/services/adService.ts
@@ -1,3 +1,5 @@
+import { telegramAuthHeaders } from '../lib/telegramAuth';
+
 export interface AdEligibilityResponse {
   allowed: boolean;
   next_available_at?: string;
@@ -52,7 +54,8 @@ class AdService {
         `${this.baseUrl}/api/ads/eligibility?user_id=${userId}&type=${type}&first_session=${firstSession ? 1 : 0}`,
         {
           method: 'GET',
-          // No Content-Type header on GET to avoid preflight
+          // initData header authenticates the user server-side (triggers a CORS preflight, which the backend handles)
+          headers: telegramAuthHeaders(),
         }
       );
 
@@ -71,9 +74,7 @@ class AdService {
     console.log(`[AdService] Starting ad session: user_id=${userId}, type=${type}`);
     const response = await fetch(`${this.baseUrl}/api/ads/start`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify({
         user_id: userId,
         type,
@@ -96,9 +97,7 @@ class AdService {
     console.log(`[AdService] Completing ad session: user_id=${userId}, type=${type}, session_id=${sessionId}, completed=${completed}`);
     const response = await fetch(`${this.baseUrl}/api/ads/complete`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: telegramAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify({
         user_id: userId,
         type,


### PR DESCRIPTION
Frontend half of the auth fix for the unauthenticated gem-minting hole. Every call to `/api/ads/*` and `/api/create-invoice` now sends `X-Telegram-Init-Data`; the backend will verify it (HMAC) and derive the user id from it instead of trusting a client-supplied `user_id`.

- New `src/lib/telegramAuth.ts`; wired `adService.ts`, `usePassiveAd.ts`, `Store.tsx`.
- `vite build` passes.
- **Deploy order:** this (frontend) goes first; backend enforcement follows. Sending the header while the backend still ignores it is a no-op, so there's no breakage window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced backend request handling for ad operations (eligibility checks and session management) and payment processing (gem purchases, subscriptions, and invoices) with improved request header integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->