### PR TITLE
Phase 2: edge-fn auth (get-user-status + claim-daily-reward initData)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -80,7 +80,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const fetchViaGetUserStatus = async (tgUser: any) => {
     const { data: statusData, error: statusError } = await supabase.functions.invoke('get-user-status', {
-      body: { telegram_id: tgUser.id }
+      body: { telegram_id: tgUser.id, initData: (window as any)?.Telegram?.WebApp?.initData || '' }
     });
     if (!statusError && statusData) {
       setUser({
@@ -104,7 +104,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       if (lastClaim === today) return;
 
       const { data, error } = await supabase.functions.invoke('claim-daily-reward', {
-        body: { telegram_id: telegramId }
+        body: { telegram_id: telegramId, initData: (window as any)?.Telegram?.WebApp?.initData || '' }
       });
 
       if (!error && data?.awarded) {

--- a/src/hooks/useHeaderStats.ts
+++ b/src/hooks/useHeaderStats.ts
@@ -48,7 +48,7 @@ async function fetchHeaderStats() {
   }
 
   const { data, error } = await supabase.functions.invoke('get-user-status', {
-    body: { telegram_id }
+    body: { telegram_id, initData: (window as any)?.Telegram?.WebApp?.initData || '' }
   });
 
   if (error) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -28,7 +28,7 @@ class ApiService {
   async getUserStatus(telegramId: number): Promise<Pick<UserStats, 'gems' | 'messages_today' | 'subscription_type'> | null> {
     try {
       const { data, error } = await supabase.functions.invoke('get-user-status', {
-        body: { telegram_id: telegramId }
+        body: { telegram_id: telegramId, initData: (window as any)?.Telegram?.WebApp?.initData || '' }
       });
 
       if (error) {
@@ -134,7 +134,7 @@ class ApiService {
 
       // Call the claim-daily-reward edge function
       const { data, error } = await supabase.functions.invoke('claim-daily-reward', {
-        body: { telegram_id: telegramId }
+        body: { telegram_id: telegramId, initData: (window as any)?.Telegram?.WebApp?.initData || '' }
       });
 
       if (error) throw error;

--- a/supabase/functions/_shared/telegram-auth.ts
+++ b/supabase/functions/_shared/telegram-auth.ts
@@ -1,0 +1,66 @@
+// Telegram Mini-App initData verification for edge functions.
+// Uses the SAME proven algorithm as upsert-user (crypto.subtle; key="WebAppData", msg=bot token;
+// data-check-string = all params except `hash`, sorted; matches Telegram's spec and is already
+// validated in production by upsert-user). Returns the VERIFIED telegram user id, or null.
+//
+// Use this to authenticate edge functions: derive the user id from initData and IGNORE any
+// client-supplied telegram_id — prevents acting on behalf of another user.
+
+const ALLOWED_ORIGINS = [
+  'https://secret-share.com',
+  'https://t.me',
+  'https://web.telegram.org',
+];
+
+export function corsHeadersFor(origin: string | null): Record<string, string> {
+  const allow = origin && ALLOWED_ORIGINS.includes(origin) ? origin : 'https://secret-share.com';
+  return {
+    'Access-Control-Allow-Origin': allow,
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-telegram-init-data',
+  };
+}
+
+// maxAgeSec defaults to 24h: these endpoints are polled with the launch-time initData, so a tight
+// window would 401 legitimate users who keep the Mini-App open. 24h limits replay blast radius.
+export async function verifyTelegramInitData(
+  initData: string,
+  botToken: string,
+  maxAgeSec = 86400,
+): Promise<number | null> {
+  try {
+    if (!initData || !botToken) return null;
+    const params = new URLSearchParams(initData);
+    const hash = params.get('hash');
+    if (!hash) return null;
+    params.delete('hash');
+
+    const arr: string[] = [];
+    for (const [k, v] of params.entries()) arr.push(`${k}=${v}`);
+    arr.sort();
+    const dataCheckString = arr.join('\n');
+
+    const secretKey = await crypto.subtle.importKey(
+      'raw', new TextEncoder().encode('WebAppData'),
+      { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+    );
+    const tokenBuffer = await crypto.subtle.sign('HMAC', secretKey, new TextEncoder().encode(botToken));
+    const verificationKey = await crypto.subtle.importKey(
+      'raw', tokenBuffer, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+    );
+    const expectedBuffer = await crypto.subtle.sign('HMAC', verificationKey, new TextEncoder().encode(dataCheckString));
+    const expectedHash = Array.from(new Uint8Array(expectedBuffer))
+      .map((b) => b.toString(16).padStart(2, '0')).join('');
+    if (hash !== expectedHash) return null;
+
+    const authDate = params.get('auth_date');
+    if (!authDate) return null;
+    if (Math.floor(Date.now() / 1000) - parseInt(authDate, 10) > maxAgeSec) return null;
+
+    const userParam = params.get('user');
+    if (!userParam) return null;
+    const uid = JSON.parse(userParam).id;
+    return (typeof uid === 'number' && uid > 0) ? uid : null;
+  } catch (_e) {
+    return null;
+  }
+}

--- a/supabase/functions/claim-daily-reward/index.ts
+++ b/supabase/functions/claim-daily-reward/index.ts
@@ -1,19 +1,23 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
-import { corsHeaders } from '../_shared/cors.ts'
+import { verifyTelegramInitData, corsHeadersFor } from '../_shared/telegram-auth.ts'
 
 serve(async (req) => {
+  const corsHeaders = corsHeadersFor(req.headers.get('Origin'))
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders })
   }
 
   try {
-    const { telegram_id } = await req.json()
-
+    const body = await req.json()
+    // Authenticate via signed Telegram initData; derive the user id from it. This MUTATES (grants
+    // daily gems) — previously callable for ANY telegram_id with no auth.
+    const botToken = Deno.env.get('TELEGRAM_BOT_TOKEN') ?? ''
+    const telegram_id = await verifyTelegramInitData(body?.initData ?? '', botToken)
     if (!telegram_id) {
       return new Response(
-        JSON.stringify({ error: 'telegram_id is required' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: 'unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
@@ -22,7 +26,6 @@ serve(async (req) => {
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
     )
 
-    // Call the existing process_daily_return_bonus RPC
     const { data, error } = await supabaseClient.rpc('process_daily_return_bonus', {
       p_user_id: telegram_id
     })
@@ -35,7 +38,6 @@ serve(async (req) => {
       )
     }
 
-    // RPC returns dict with: awarded, amount, reward_type, streak, day_in_cycle
     const result = Array.isArray(data) ? data[0] : data
 
     return new Response(

--- a/supabase/functions/get-user-status/index.ts
+++ b/supabase/functions/get-user-status/index.ts
@@ -1,86 +1,66 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { verifyTelegramInitData, corsHeadersFor } from '../_shared/telegram-auth.ts'
 
 serve(async (req) => {
-  // Handle CORS preflight requests
+  const corsHeaders = corsHeadersFor(req.headers.get('Origin'))
   if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
+    return new Response(null, { headers: corsHeaders })
   }
 
   try {
+    const body = await req.json()
+    // Authenticate via signed Telegram initData; derive the user id from it (never trust a
+    // client-supplied telegram_id). This endpoint previously returned gems/tier/messages for ANY
+    // telegram_id with no auth.
+    const botToken = Deno.env.get('TELEGRAM_BOT_TOKEN') ?? ''
+    const telegram_id = await verifyTelegramInitData(body?.initData ?? '', botToken)
+    if (!telegram_id) {
+      return new Response(
+        JSON.stringify({ error: 'unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
     const supabaseClient = createClient(
       Deno.env.get('SUPABASE_URL') ?? '',
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    );
+    )
 
-    const { telegram_id } = await req.json();
-
-    if (!telegram_id) {
-      return new Response(
-        JSON.stringify({ error: 'telegram_id is required' }),
-        { 
-          status: 400, 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-        }
-      );
-    }
-
-    // Fetch user data using the existing secure function
     const { data, error } = await supabaseClient.rpc('get_user_stats_safe', {
       p_telegram_id: telegram_id
-    });
+    })
 
     if (error) {
-      console.error('Database error:', error);
+      console.error('Database error:', error)
       return new Response(
         JSON.stringify({ error: 'Failed to fetch user status' }),
-        { 
-          status: 500, 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-        }
-      );
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
     }
 
     if (!data || data.length === 0) {
       return new Response(
-        JSON.stringify({ 
-          gems: 100, // Default gems for new users
-          messages_today: 0,
-          subscription_type: null 
-        }),
-        { 
-          status: 200, 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-        }
-      );
+        JSON.stringify({ gems: 100, messages_today: 0, subscription_type: null }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
     }
 
-    const userData = data[0];
+    const userData = data[0]
     return new Response(
       JSON.stringify({
         gems: userData.gems || 0,
         messages_today: userData.messages_today || 0,
         subscription_type: userData.subscription_type
       }),
-      { 
-        status: 200, 
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-      }
-    );
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
 
   } catch (error) {
-    console.error('Error processing request:', error);
+    console.error('Error processing request:', error)
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { 
-        status: 500, 
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-      }
-    );
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
   }
 })


### PR DESCRIPTION
Frontend-first half: send signed Telegram initData to get-user-status + claim-daily-reward; edge fns updated to verify it + derive user id (ignore client telegram_id) + origin-allowlist CORS. Closes the last security gap (gems/tier leak + daily-gem grant by arbitrary telegram_id). Reuses upsert-user's proven validation. Deploy frontend first, then the edge fns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced authentication verification for Telegram Mini App user sessions
  * Strengthened validation during daily reward claims and account status checks
  * Improved cross-origin request handling for API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->